### PR TITLE
Add user feedback

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -365,6 +365,16 @@ main(int argc, char **argv)
 
         sentry_capture_event(event);
     }
+    if (has_arg(argc, argv, "capture-user-feedback")) {
+        sentry_value_t event = sentry_value_new_message_event(
+            SENTRY_LEVEL_INFO, "my-logger", "Hello World!");
+        sentry_uuid_t event_id = sentry_capture_event(event);
+
+        sentry_value_t user_feedback = sentry_value_new_user_feedback(&event_id,
+            "some-name", "some-email", "some-comment");
+
+        sentry_capture_user_feedback(user_feedback);
+    }
 
     if (has_arg(argc, argv, "capture-transaction")) {
         sentry_transaction_context_t *tx_ctx

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1889,6 +1889,27 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_set_name_n(
     sentry_transaction_t *transaction, const char *name, size_t name_len);
 
 /**
+ * Creates a new User Feedback with a specific name, email and comments.
+ *
+ * See https://develop.sentry.dev/sdk/envelopes/#user-feedback
+ *
+ * User Feedback has to be associated with a specific event that has been
+ * sent to Sentry earlier.
+ */
+SENTRY_API sentry_value_t sentry_value_new_user_feedback(
+    const sentry_uuid_t *uuid,
+    const char *name, const char *email, const char *comments);
+SENTRY_API sentry_value_t sentry_value_new_user_feedback_n(
+    const sentry_uuid_t *uuid,
+    const char *name, size_t name_len, const char *email, size_t email_len,
+    const char *comments, size_t comments_len);
+
+/**
+ * Captures a manually created User Feedback and sends it to Sentry.
+ */
+SENTRY_API void sentry_capture_user_feedback(sentry_value_t user_feedback);
+
+/**
  * The status of a Span or Transaction.
  *
  * See https://develop.sentry.dev/sdk/event-payloads/span/ for documentation.

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -296,6 +296,36 @@ sentry__envelope_add_transaction(
 }
 
 sentry_envelope_item_t *
+sentry__envelope_add_user_feedback(
+    sentry_envelope_t *envelope, sentry_value_t user_feedback)
+{
+    sentry_envelope_item_t *item = envelope_add_item(envelope);
+    if (!item) {
+        return NULL;
+    }
+
+    sentry_jsonwriter_t *jw = sentry__jsonwriter_new(NULL);
+    if (!jw) {
+        return NULL;
+    }
+
+    sentry_value_t event_id = sentry__ensure_event_id(user_feedback, NULL);
+
+    sentry__jsonwriter_write_value(jw, user_feedback);
+    item->payload = sentry__jsonwriter_into_string(jw, &item->payload_len);
+
+    sentry__envelope_item_set_header(
+        item, "type", sentry_value_new_string("user_report"));
+    sentry_value_t length = sentry_value_new_int32((int32_t)item->payload_len);
+    sentry__envelope_item_set_header(item, "length", length);
+
+    sentry_value_incref(event_id);
+    sentry__envelope_set_header(envelope, "event_id", event_id);
+
+    return item;
+}
+
+sentry_envelope_item_t *
 sentry__envelope_add_session(
     sentry_envelope_t *envelope, const sentry_session_t *session)
 {

--- a/src/sentry_envelope.h
+++ b/src/sentry_envelope.h
@@ -43,6 +43,12 @@ sentry_envelope_item_t *sentry__envelope_add_transaction(
     sentry_envelope_t *envelope, sentry_value_t transaction);
 
 /**
+ * Add a user feedback to this envelope.
+ */
+sentry_envelope_item_t *sentry__envelope_add_user_feedback(
+    sentry_envelope_t *envelope, sentry_value_t user_feedback);
+
+/**
  * Add a session to this envelope.
  */
 sentry_envelope_item_t *sentry__envelope_add_session(

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -1265,6 +1265,39 @@ sentry_value_new_stacktrace(void **ips, size_t len)
     return stacktrace;
 }
 
+sentry_value_t sentry_value_new_user_feedback(const sentry_uuid_t *uuid,
+    const char *name, const char *email, const char *comments)
+{
+    size_t name_len = name ? strlen(name) : 0;
+    size_t email_len = email ? strlen(email) : 0;
+    size_t comments_len = email ? strlen(comments) : 0;
+    return sentry_value_new_user_feedback_n(uuid, name, name_len,
+        email, email_len, comments, comments_len);
+}
+sentry_value_t sentry_value_new_user_feedback_n(const sentry_uuid_t *uuid,
+    const char *name, size_t name_len, const char *email, size_t email_len,
+    const char *comments, size_t comments_len)
+{
+    sentry_value_t rv = sentry_value_new_object();
+
+    sentry_value_set_by_key(rv, "event_id", sentry__value_new_uuid(uuid));
+
+    if (name) {
+        sentry_value_set_by_key(rv, "name",
+            sentry_value_new_string_n(name, name_len));
+    }
+    if (email) {
+        sentry_value_set_by_key(rv, "email",
+            sentry_value_new_string_n(email, email_len));
+    }
+    if (comments) {
+        sentry_value_set_by_key(rv, "comments",
+            sentry_value_new_string_n(comments, comments_len));
+    }
+
+    return rv;
+}
+
 static sentry_value_t
 sentry__get_or_insert_values_list(sentry_value_t parent, const char *key)
 {

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -37,6 +37,19 @@ def assert_session(envelope, extra_assertion=None):
     if extra_assertion:
         assert_matches(session, extra_assertion)
 
+def assert_user_feedback(envelope, extra_assertion=None):
+    user_feedback = None
+    for item in envelope:
+        if item.headers.get("type") == "user_report" and item.payload.json is not None:
+            user_feedback = item.payload.json
+
+    assert user_feedback is not None
+    assert user_feedback["name"] == "some-name"
+    assert user_feedback["email"] == "some-email"
+    assert user_feedback["comments"] == "some-comment"
+    if extra_assertion:
+        assert_matches(user_feedback, extra_assertion)
+
 
 def assert_meta(
     envelope,

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -16,6 +16,7 @@ from .assertions import (
     assert_exception,
     assert_inproc_crash,
     assert_session,
+    assert_user_feedback,
     assert_minidump,
     assert_breakpad_crash,
 )
@@ -115,6 +116,34 @@ def test_capture_and_session_http(cmake, httpserver):
     output = httpserver.log[1][0].get_data()
     envelope = Envelope.deserialize(output)
     assert_session(envelope, {"status": "exited", "errors": 0})
+
+def test_user_feedback_http(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
+
+    httpserver.expect_request(
+        "/api/123456/envelope/",
+        headers={"x-sentry-auth": auth_header},
+    ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
+    run(
+        tmp_path,
+        "sentry_example",
+        ["log", "capture-user-feedback"],
+        check=True,
+        env=env,
+    )
+
+    assert len(httpserver.log) == 2
+    output = httpserver.log[0][0].get_data()
+    envelope = Envelope.deserialize(output)
+
+    assert_event(envelope)
+
+    output = httpserver.log[1][0].get_data()
+    envelope = Envelope.deserialize(output)
+
+    assert_user_feedback(envelope)
 
 
 def test_exception_and_session_http(cmake, httpserver):

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -772,3 +772,24 @@ SENTRY_TEST(thread_without_name_still_valid)
         test_name);
     sentry_value_decref(thread);
 }
+
+SENTRY_TEST(user_feedback_is_valid)
+{
+    sentry_uuid_t event_id
+        = sentry_uuid_from_string("c993afb6-b4ac-48a6-b61b-2558e601d65d");
+    sentry_value_t user_feedback = sentry_value_new_user_feedback(
+        &event_id, "some-name", "some-email", "some-comment");
+
+    TEST_CHECK(!sentry_value_is_null(user_feedback));
+    TEST_CHECK_STRING_EQUAL(sentry_value_as_string(sentry_value_get_by_key(
+        user_feedback, "name")),
+        "some-name");
+    TEST_CHECK_STRING_EQUAL(sentry_value_as_string(sentry_value_get_by_key(
+        user_feedback, "email")),
+        "some-email");
+    TEST_CHECK_STRING_EQUAL(sentry_value_as_string(sentry_value_get_by_key(
+        user_feedback, "comments")),
+        "some-comment");
+
+    sentry_value_decref(user_feedback);
+}


### PR DESCRIPTION
This PR introduces a new API allowing to create/capture user feedback for specific events (similar functionality is offered by native [Android](https://docs.sentry.io/platforms/android/user-feedback/) and [Apple](https://docs.sentry.io/platforms/apple/user-feedback/) SDKs).

It will be later exposed to the [Unreal Engine plugin](https://github.com/getsentry/sentry-unreal) where user feedback capabilities have been requested recently. While the existing [user feedback endpoint](https://docs.sentry.io/product/user-feedback/) provides an alternative it requires deviating from our current approach of utilizing the native SDKs for client app communication with Sentry there.

Related to #885